### PR TITLE
Move iris size to Penetration Testing section

### DIFF
--- a/EYE_Toolbox_Overview.adoc
+++ b/EYE_Toolbox_Overview.adoc
@@ -70,9 +70,8 @@ Eye PAD testing can be done in a variety of ways. The evaluator may use differen
 The tools and media for the creation of artefacts are defined for all tests in the link:EYE_Toolbox_Inventory.adoc[Eye Toolbox Inventory]. Each attack specifies which tools and media are to be used in the creation of artefacts for that test.
 
 === Image Recommendations
-Based on earlier work[2], the Evaluator should attempt to acquire images where the iris diameter is at least 75 pixels as the source. When creating printed photos, the photo should be printed to have an equivalent of 1200 DPI.
 
-Note that when tests require the use of the contact lenses, the printed image of the iris must match the diameter of the contact lens for proper overlay.
+Note that when tests require the use of the contact lenses, the printed image of the iris shall match the diameter of the contact lens for proper overlay.
 
 === Enrolment Preparation - All Artefacts
 

--- a/attacks/01_01-Eye-attack.adoc
+++ b/attacks/01_01-Eye-attack.adoc
@@ -49,6 +49,8 @@ The evaluator may, for example, change color effects of the camera to change the
 + 
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE. In addition, the evaluator may deliberately warp a printed photo, trying to simulate facial motion (Warped photo attack).
 
+- Based on earlier work[2], the Evaluator should attempt to acquire images where the iris diameter is at least 75 pixels as the source. When creating printed photos, the photo should be printed to have an equivalent of 1200 DPI.
+
 === Attack Potential Rating Suggestion
 The attack potential that is required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
 

--- a/attacks/02_01-Eye-attack.adoc
+++ b/attacks/02_01-Eye-attack.adoc
@@ -49,6 +49,8 @@ The evaluator may, for example, change color effects of the camera to change the
 + 
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE.
 
+- Based on earlier work[2], the Evaluator should attempt to acquire images where the iris diameter is at least 75 pixels as the source.
+
 === Attack Potential Rating Suggestion
 The attack potential that is required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
 

--- a/attacks/03_01-Eye-attack.adoc
+++ b/attacks/03_01-Eye-attack.adoc
@@ -49,6 +49,8 @@ The evaluator may, for example, change color effects of the camera to change the
 + 
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE.
 
+- Based on earlier work[2], the Evaluator should attempt to acquire images where the iris diameter is at least 75 pixels as the source.
+
 === Attack Potential Rating Suggestion
 The attack potential that is required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
 

--- a/attacks/04_01-Eye-attack.adoc
+++ b/attacks/04_01-Eye-attack.adoc
@@ -51,6 +51,8 @@ The evaluator may, for example, change color effects of the camera to change the
 + 
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE. In addition, the evaluator may deliberately warp a printed photo, trying to simulate facial motion (Warped photo attack).
 
+- Based on earlier work[2], the Evaluator should attempt to acquire images where the iris diameter is at least 75 pixels as the source. When creating printed photos, the photo should be printed to have an equivalent of 1200 DPI.
+
 === Attack Potential Rating Suggestion
 The attack potential that is required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
 

--- a/attacks/05_01-Eye-attack.adoc
+++ b/attacks/05_01-Eye-attack.adoc
@@ -58,6 +58,8 @@ The evaluator may, for example, change color effects of the camera to change the
 + 
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE. In addition to that, the evaluator may deliberately warp a printed photo, trying to simulate facial motion (Warped photo attack).
 
+- Based on earlier work[2], the Evaluator should attempt to acquire images where the iris diameter is at least 75 pixels as the source. When creating printed photos, the photo should be printed to have an equivalent of 1200 DPI.
+
 === Attack Potential Rating Suggestion
 The attack potential that is required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
 


### PR DESCRIPTION
Moves information about iris diameter and print resolution from **Image Recommendations** to the **Penetration Testing Suggestions** section for each attack. Also changes "must" to "shall" for contact lens diameter in **Image Recommendations**.

Merges into copy-edit branch gfiumara-edits-july2020. Merging would resolve #9.